### PR TITLE
Add publishing conventions

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <project>
   <modelVersion>4.0.0</modelVersion>
-  <name>OpenSourceProjects_CucmberCompanion Config DSL Script</name>
-  <groupId>OpenSourceProjects_CucmberCompanion</groupId>
-  <artifactId>OpenSourceProjects_CucmberCompanion_dsl</artifactId>
+  <name>OpenSourceProjects_CucumberCompanion Config DSL Script</name>
+  <groupId>OpenSourceProjects_CucumberCompanion</groupId>
+  <artifactId>OpenSourceProjects_CucumberCompanion_dsl</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <parent>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -25,4 +25,41 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2023.05"
 
 project {
+    buildType {
+        name = "Publish Cucumber Companion"
+        id = RelativeId(name.toId())
+        description = "Publishes the Cucumber Companion Plugins"
+
+        vcs {
+            root(AbsoluteId("OpenSourceProjects_CucmberCompanion_HttpsGithubComGradleCucumberCompanion"))
+            checkoutMode = CheckoutMode.ON_AGENT
+            cleanCheckout = true
+        }
+
+        requirements {
+            contains("teamcity.agent.jvm.os.name", "Linux")
+        }
+
+        steps {
+            gradle {
+                useGradleWrapper = true
+                tasks = "clean publishAllPublicationsToArtifactoryRepository"
+                gradleParams = "--build-cache --no-configuration-cache"
+            }
+        }
+        params {
+            param("env.ORG_GRADLE_PROJECT_sonatypeUsername", "%mavenCentralStagingRepoUser%")
+            password("env.ORG_GRADLE_PROJECT_sonatypePassword", "%mavenCentralStagingRepoPassword%")
+            param("env.ORG_GRADLE_PROJECT_artifactoryUsername", "%artifactoryUsername%")
+            password("env.ORG_GRADLE_PROJECT_artifactoryPassword", "%artifactoryPassword%")
+            password("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
+            password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
+        }
+    }
+    params {
+        param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%")
+        param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
+        param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
+        password("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,17 @@
-val isCI = System.getenv("CI")?.toBoolean() ?: false
-val isCC = project.gradle.startParameter.isConfigurationCacheRequested
+plugins {
+    alias(libs.plugins.nexusPublish)
+}
 
-require(!isCC || !isCI) { "Configuration-Cache should be disabled on CI" }
+nexusPublishing {
+    packageGroup.set("org.gradle")
+    this.repositories {
+        sonatype {
+            // https://central.sonatype.org/news/20210223_new-users-on-s01/
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+        create("artifactory") {
+            nexusUrl.set(uri("https://repo.gradle.org/artifactory/enterprise-libs-release-candidates/"))
+        }
+    }
+}

--- a/gradle-plugin/src/main/kotlin/org/gradle/cucumber/companion/CucumberCompanionHelper.kt
+++ b/gradle-plugin/src/main/kotlin/org/gradle/cucumber/companion/CucumberCompanionHelper.kt
@@ -34,11 +34,11 @@ fun generateCucumberSuiteCompanion(
     val outputDir = buildDirectory.dir("generated-sources/cucumberCompanion-$name")
     companionTask.configure {
         // this is a bit icky, ideally we'd use a SourceDirectorySet ourselves, but I'm not sure that is proper
-        it.cucumberFeatureSources.set(sourceSet.resources.srcDirs.first())
-        it.outputDirectory.set(outputDir)
+        this.cucumberFeatureSources.set(sourceSet.resources.srcDirs.first())
+        this.outputDirectory.set(outputDir)
     }
     sourceSet.java.srcDir(outputDir)
     taskContainer.named(sourceSet.compileJavaTaskName) {
-        it.dependsOn(companionTask.name)
+        this.dependsOn(companionTask.name)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,12 @@ groovy-xml.module = "org.codehaus.groovy:groovy-xml"
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock" }
 spock-core.module = "org.spockframework:spock-core"
 maven-core = { module = "org.apache.maven:maven-core", version.ref = "mavenMaxCompatible" }
-maven-pluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "mavenMaxCompatible"}
+maven-pluginApi = { module = "org.apache.maven:maven-plugin-api", version.ref = "mavenMaxCompatible" }
 maven-pluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-annotations", version = "3.9.0" }
 takariIntegrationTesting = { module = "io.takari.maven.plugins:takari-plugin-integration-testing", version = "3.0.1" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.1" }
+shadow = { module = "com.github.johnrengelman:shadow", version = "8.1.1" }
 
 [plugins]
 mavenPluginDevelopment = { id = "de.benediktritter.maven-plugin-development", version = "0.4.2" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }

--- a/gradle/plugins/build-logic/build.gradle.kts
+++ b/gradle/plugins/build-logic/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     implementation(kotlin("gradle-plugin"))
     // hack to make the version catalog available to convention plugin scripts (https://github.com/gradle/gradle/issues/17968)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+    implementation(libs.shadow)
 }

--- a/gradle/plugins/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
+++ b/gradle/plugins/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    `maven-publish`
+    signing
+    id("com.github.johnrengelman.shadow")
+}
+
+publishing {
+    publications {
+        withType(MavenPublication::class.java) {
+            signing.sign(this)
+
+            pom {
+                name.set(provider {
+                    artifactId.split("-").joinToString(" ") { it.replaceFirstChar(Character::toUpperCase) }
+                } )
+                description.set(provider { project.description })
+
+                url.set("https://github.com/gradle/cucumber-companion/")
+                licenses {
+                    license {
+                        name.set("Apache-2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+                developers {
+                    developer {
+                        name.set("The Gradle team")
+                        organization.set("Gradle Inc.")
+                        organizationUrl.set("https://gradle.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/gradle/cucumber-companion.git")
+                    developerConnection.set("scm:git:ssh://git@github.com:gradle/cucumber-companion.git")
+                    url.set("https://github.com/gradle/cucumber-companion/")
+                }
+            }
+        }
+    }
+}
+
+tasks.withType<Sign>().configureEach {
+    onlyIf("Run on TeamCity") { System.getenv("TEAMCITY_VERSION") != null }
+}
+
+signing {
+    useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"))
+}

--- a/maven-plugin/build.gradle.kts
+++ b/maven-plugin/build.gradle.kts
@@ -10,26 +10,22 @@ plugins {
     groovy
     `maven-publish`
     `jvm-test-suite`
-    `java-test-fixtures`
     alias(libs.plugins.mavenPluginDevelopment)
-    alias(libs.plugins.shadow)
     id("conventions.maven-plugin-testing")
+    id("conventions.publishing")
 }
 
-val ourArtifactId = "cucumber-companion-plugin"
+project.description = "Maven Plugin making Cucumber tests compatible with Gradle Enterprise test acceleration features"
+val mavenPluginArtifactId = "cucumber-companion-maven-plugin"
 
 mavenPlugin {
-    artifactId.set(ourArtifactId)
+    artifactId.set(mavenPluginArtifactId)
+    dependencies = configurations.named("shadow")
 }
 
-publishing {
-    publications {
-        val maven by creating(MavenPublication::class) {
-            artifactId = ourArtifactId
-            //from(components["java"])
-        }
-        shadow.component(maven)
-    }
+val mavenJava by publishing.publications.creating(MavenPublication::class) {
+    artifactId = mavenPluginArtifactId
+    shadow.component(this)
 }
 
 java {
@@ -59,8 +55,9 @@ mavenPluginTesting {
     mavenVersions = setOf(
         libs.versions.mavenMinCompatible.get(),
         "3.8.7",
-        libs.versions.mavenMaxCompatible.get())
-    pluginPublication = publishing.publications.named<MavenPublication>("maven")
+        libs.versions.mavenMaxCompatible.get()
+    )
+    pluginPublication = mavenJava
 }
 
 // adapted from the mavenPluginDevelopment plugin, otherwise the shadowJar doesn't pickup the necessary metadata files

--- a/maven-plugin/src/functionalTest/groovy/org/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/org/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
@@ -36,7 +36,7 @@ class BaseCucumberCompanionMavenFuncTest extends BaseMavenFuncTest {
             addPlugin("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0")
             addPlugin("org.apache.maven.plugins", "maven-resources-plugin", "3.3.1")
             addPlugin("org.apache.maven.plugins", "maven-surefire-plugin", SUREFIRE_VERSION)
-            addPlugin("org.gradle.cucumber.companion", "cucumber-companion-plugin", '${it-project.version}') {
+            addPlugin("org.gradle.cucumber.companion", "cucumber-companion-maven-plugin", '${it-project.version}') {
                 executions {
                     execution {
                         id("generate-companion")


### PR DESCRIPTION
~I wonder whether we should publish gradle and maven plugins with different groupId but same artifactId? Otherwise the naming would clash or need to be inconsistent.~

Currently, `publishToMavenLocal` creates the following artifacts:
```
$ ls ~/.m2/repository/org/gradle/cucumber/companion 

companion-generator  cucumber-companion-gradle-plugin  cucumber-companion-maven-plugin  gradle-plugin  org.gradle.cucumber.companion.gradle.plugin
```
