### PR TITLE
Fix maven func test task discovery

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -2,7 +2,6 @@
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-
 plugins {
     groovy
     `kotlin-dsl`
@@ -88,7 +87,6 @@ tasks.register("allGradleCrossVersionTests") {
     group = "Cross Version"
     description = "Runs all ${allCrossVersionTests.size} gradle cross version test tasks"
 }
-
 gradlePlugin {
     // Define the plugin
     val cucumberCompanion by plugins.creating {


### PR DESCRIPTION
Prior to this change, registration of the maven func test tasks apparently was "too lazy". They were not recognized by IntelliJ after refreshing the project: 
![image](https://github.com/gradle/cucumber-companion/assets/317179/728d467f-8c0f-48bb-9af2-100d4d56b45b)
With this change in place, tasks are properly recognized:
![image](https://github.com/gradle/cucumber-companion/assets/317179/f3f67753-f480-488c-98a1-ad1a67d2ca96)
