### PR TITLE
Feature/81 allow for empty suites

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -73,9 +73,6 @@ testing {
 The added companion task has the pattern of `<suiteName>GenerateCucumberSuiteCompanion`, so for a suite named `functionalTest` it would be `functionalTestGenerateCucumberSuiteCompanion`.
 However, there's usually no need to call it manually since the `compile<suiteName>Java` task depends on it.
 
-To add `failIfNoTests = false` to the generated `@Suite` annotation in companions, just add second parameter `true`
-to the invocation.
-
 ==== Disabling generation for the default `test` task/suite
 
 If you need to disable the generation of companion files for the default `test` task/suite, then you can do so via the `cucumberCompanion` extension.
@@ -120,6 +117,37 @@ cucumberCompanion {
 }
 ----
 
+For the same outcome at the test suite level, define:
+
+`build.gradle.kts` (Kotlin)
+[source,kotlin]
+----
+testing {
+    suites {
+        functionalTest {
+            generateCucumberSuiteCompanion(project) {
+                allowEmptySuites.set(true)
+            }
+        }
+    }
+}
+----
+
+`build.gradle` (Groovy)
+[source,groovy]
+----
+testing {
+    suites {
+        functionalTest {
+            cucumberCompanion.generateCucumberSuiteCompanion(delegate) {
+                allowEmptySuites = true
+            }
+        }
+    }
+}
+----
+
+_Note that_ the configuration of a test suite will have higher priority than plugin-level configuration.
 
 === Maven
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -73,6 +73,9 @@ testing {
 The added companion task has the pattern of `<suiteName>GenerateCucumberSuiteCompanion`, so for a suite named `functionalTest` it would be `functionalTestGenerateCucumberSuiteCompanion`.
 However, there's usually no need to call it manually since the `compile<suiteName>Java` task depends on it.
 
+To add `failIfNoTests = false` to the generated `@Suite` annotation in companions, just add second parameter `true`
+to the invocation.
+
 ==== Disabling generation for the default `test` task/suite
 
 If you need to disable the generation of companion files for the default `test` task/suite, then you can do so via the `cucumberCompanion` extension.
@@ -92,6 +95,31 @@ cucumberCompanion {
     enableForStandardTestTask = false
 }
 ----
+
+==== Generation of companions not failing if there are no tests
+
+This is interesting especially for test cases retries when all but few tests being filtered out.
+It adds `failIfNoTests = false` to the generated `@Suite` annotation.
+By default, companions execution will fail if all tests of a suite have been filtered out
+in the JUnit5 `discovery` phase.
+See also https://github.com/gradle/test-retry-gradle-plugin[Test Retry Gradle Plugin].
+
+`build.gradle.kts` (Kotlin)
+[source,kotlin]
+----
+cucumberCompanion {
+    allowEmptySuites.set(true)
+}
+----
+
+`build.gradle` (Groovy)
+[source,groovy]
+----
+cucumberCompanion {
+    allowEmptySuites = true
+}
+----
+
 
 === Maven
 
@@ -138,6 +166,36 @@ If you prefer to run your tests with Failsafe instead, then you can configure th
                     </goals>
                     <configuration>
                         <generatedFileNameSuffix>IT</generatedFileNameSuffix>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+----
+
+==== Generation of companions not failing if there are no tests
+
+This is interesting especially for test cases retries when all but few tests being filtered out.
+It adds `failIfNoTests = false` to the generated `@Suite` annotation.
+By default, companions execution will fail if all tests of a suite have been filtered out
+in the JUnit5 `discovery` phase.
+
+[source,xml,subs="attributes+"]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.gradle.cucumber.companion</groupId>
+            <artifactId>cucumber-companion-maven-plugin</artifactId>
+            <version>{version}</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>generate-cucumber-companion-files</goal>
+                    </goals>
+                    <configuration>
+                        <allowEmptySuites>true</allowEmptySuites>
                     </configuration>
                 </execution>
             </executions>

--- a/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionGenerator.java
+++ b/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionGenerator.java
@@ -33,7 +33,7 @@ public class CompanionGenerator {
         return new CompanionFile(sourceDir, targetDir, actual);
     }
 
-    public static void create(CompanionFile companionFile) throws IOException {
+    public static void create(CompanionFile companionFile, boolean allowEmptySuites) throws IOException {
         // We could have included a templating engine, but it is just a few lines
         // and adding the dependency seems overkill.
         ensureParentDirectoryExists(companionFile.getDestination());
@@ -46,6 +46,9 @@ public class CompanionGenerator {
                 bw.write(NEW_LINE);
             }
             bw.write("@org.junit.platform.suite.api.Suite");
+            if(allowEmptySuites) {
+                bw.write("(failIfNoTests = false)");
+            }
             bw.write(NEW_LINE);
             bw.write("@org.junit.platform.suite.api.SelectClasspathResource(\"");
             bw.write(companionFile.getClassPathResource().replace('\\', '/'));

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CompanionAssertions.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CompanionAssertions.groovy
@@ -33,7 +33,7 @@ class CompanionAssertions {
         Path companionFile = fileResolver.apply(companion)
         assert Files.exists(companionFile)
         def expected = """${companion.packageName ? "                    package $companion.packageName;\n\n" : ''}\
-                    @org.junit.platform.suite.api.Suite
+                    @org.junit.platform.suite.api.Suite${companion.allowEmptySuites ? "(failIfNoTests = false)": ''}
                     @org.junit.platform.suite.api.SelectClasspathResource("${companion.classPathResource}")
                     class ${companion.className} {
                         public static final String CONTENT_HASH = "${companion.contentHash}";

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFixture.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFixture.groovy
@@ -24,9 +24,9 @@ import spock.util.io.FileSystemFixture
 class CucumberFixture {
 
     @Memoized
-    List<ExpectedCompanionFile> expectedCompanionFiles(String suffix = '', List<CucumberFeature> features = CucumberFeature.allSucceeding()) {
+    List<ExpectedCompanionFile> expectedCompanionFiles(String suffix = '', boolean allowEmptySuites = false, List<CucumberFeature> features = CucumberFeature.allSucceeding()) {
         features.collect {
-            ExpectedCompanionFile.create(it.featureName, it.contentHash, it.packageName, suffix)
+            ExpectedCompanionFile.create(it.featureName, it.contentHash, it.packageName, suffix, allowEmptySuites)
         }
     }
 
@@ -46,6 +46,55 @@ class CucumberFixture {
                 features.each {
                     file(it.stepFilePath).text = it.stepFileContent
                 }
+            }
+        }
+    }
+
+    void createPostDiscoveryFilter(FileSystemFixture projectDir) {
+        projectDir.create {
+            dir("src/test/java/org/junit/platform/launcher") {
+                file("TestPostDiscoveryFilter.java").text = """
+                    package org.junit.platform.launcher;
+                    
+                    import org.junit.platform.engine.*;
+                    import org.junit.platform.engine.support.descriptor.*;
+                    import org.junit.platform.launcher.PostDiscoveryFilter;
+                    import java.util.*;
+                    
+                    // allows only one, pre-defined class name in the discovery phase
+                    public class TestPostDiscoveryFilter implements PostDiscoveryFilter {
+                    
+                        private static final String FILTERED_CLASS_NAME = "user.User_Profile";
+                    
+                        public FilterResult apply(TestDescriptor testDescriptor) {
+                            if(testDescriptor.getSource().isPresent()) {
+                                TestSource testSource = testDescriptor.getSource().get();
+                                // looking for FQCN of features and their parents
+                                String className = testSource.toString();
+                                // need also to consider 'feature' children of the suite
+                                if(testSource instanceof ClassSource) {
+                                    className = ((ClassSource) testSource).getClassName();
+                                } else if(testSource instanceof ClasspathResourceSource) {
+                                    String classpathResourceName = ((ClasspathResourceSource) testSource).getClasspathResourceName();
+                                    className = classpathResourceName
+                                        .replace('/', '.')
+                                        .replace(".feature", "")
+                                        .replaceAll("[^a-zA-Z0-9_\\\\.]", "_");
+                                }
+                                return FilterResult.includedIf(FILTERED_CLASS_NAME.equalsIgnoreCase(className));
+                            }
+                            return FilterResult.excluded("Suite/Feature name doesn't match");
+                        }
+                    }
+                """
+            }
+        }
+    }
+
+    void registerPostDiscoveryFilter(FileSystemFixture projectDir) {
+        projectDir.create {
+            dir("src/test/resources/META-INF/services") {
+                file("org.junit.platform.launcher.PostDiscoveryFilter").text = "org.junit.platform.launcher.TestPostDiscoveryFilter"
             }
         }
     }

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedCompanionFile.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedCompanionFile.groovy
@@ -27,8 +27,9 @@ class ExpectedCompanionFile {
     String packageName
     String classPathResource
     String contentHash
+    boolean allowEmptySuites
 
-    static ExpectedCompanionFile create(String featureName, String contentHash, String packageName, String suffix = '') {
+    static ExpectedCompanionFile create(String featureName, String contentHash, String packageName, String suffix = '', boolean allowEmptySuites = false) {
         def safeName = featureName.replaceAll(" ", "_") + suffix
         new ExpectedCompanionFile(
             featureName,
@@ -36,7 +37,8 @@ class ExpectedCompanionFile {
             safeName,
             packageName,
             [packageName.replaceAll(/\./, '/'), featureName + ".feature"].findAll().join("/"),
-            contentHash
+            contentHash,
+            allowEmptySuites
         )
     }
 }

--- a/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/CucumberCompanionPluginFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/CucumberCompanionPluginFunctionalTest.groovy
@@ -90,10 +90,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         result.output.contains("testGenerateCucumberSuiteCompanion")
 
         def expectedCompanions = expectedCompanionFiles(
-            "", [
-            Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG,
-            Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG,
-        ].contains(variant)
+            allowEmptySuites: [Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG, Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG].contains(variant)
         )
 
         expectedCompanions.forEach {
@@ -135,7 +132,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         setupPlugin(buildScriptLanguage, variant)
         createFeatureFiles(workspace, allSucceedingFeatures)
         createStepFiles(workspace, allSucceedingFeatures)
-        createPostDiscoveryFilter(workspace)
+        createPostDiscoveryFilter(workspace, "$CucumberFeature.USER_PROFILE.packageName.$CucumberFeature.USER_PROFILE.className")
         registerPostDiscoveryFilter(workspace)
 
         when:
@@ -160,10 +157,8 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
 
         where:
         [buildScriptLanguage, variant] << [
-            BuildScriptLanguage.values(), [
-            Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG,
-            Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG,
-        ]
+            BuildScriptLanguage.values(),
+            [Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG, Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG]
         ].combinations()
     }
 
@@ -201,7 +196,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         then: "feature companion is present"
         result.output.contains("testGenerateCucumberSuiteCompanion")
 
-        expectedCompanionFiles('', false, [CucumberFeature.PRODUCT_SEARCH]).forEach {
+        expectedCompanionFiles([:], [CucumberFeature.PRODUCT_SEARCH]).forEach {
             companionAssertions.assertCompanionFile(it)
         }
 
@@ -214,7 +209,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         then: "both companion files are present"
         result.output.contains("testGenerateCucumberSuiteCompanion")
 
-        expectedCompanionFiles('', false, [CucumberFeature.PRODUCT_SEARCH, CucumberFeature.PASSWORD_RESET]).forEach {
+        expectedCompanionFiles([:], [CucumberFeature.PRODUCT_SEARCH, CucumberFeature.PASSWORD_RESET]).forEach {
             companionAssertions.assertCompanionFile(it)
         }
 
@@ -227,7 +222,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         then: "both companion files are present"
         result.output.contains("testGenerateCucumberSuiteCompanion")
 
-        expectedCompanionFiles('', false, [CucumberFeature.PRODUCT_SEARCH, CucumberFeature.PASSWORD_RESET_V2]).forEach {
+        expectedCompanionFiles([:], [CucumberFeature.PRODUCT_SEARCH, CucumberFeature.PASSWORD_RESET_V2]).forEach {
             companionAssertions.assertCompanionFile(it)
         }
 
@@ -240,12 +235,12 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         then: "one companion remains"
         result.output.contains("testGenerateCucumberSuiteCompanion")
 
-        expectedCompanionFiles('', false, [CucumberFeature.PASSWORD_RESET_V2]).forEach {
+        expectedCompanionFiles([:], [CucumberFeature.PASSWORD_RESET_V2]).forEach {
             companionAssertions.assertCompanionFile(it)
         }
 
         and: "the other is gone"
-        expectedCompanionFiles('', false, [CucumberFeature.PRODUCT_SEARCH]).forEach {
+        expectedCompanionFiles([:], [CucumberFeature.PRODUCT_SEARCH]).forEach {
             with(companionFile(it)) {
                 !Files.exists(it)
             }
@@ -259,7 +254,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         return workspace.resolve("build/generated-sources/cucumberCompanion-test/${companion.relativePath}")
     }
 
-    void setupPlugin(BuildScriptLanguage language, Variant variant = Variant.IMPLICIT_WITH_TEST_SUITES) {
+    def setupPlugin(BuildScriptLanguage language, Variant variant = Variant.IMPLICIT_WITH_TEST_SUITES) {
         switch (language) {
             case BuildScriptLanguage.GROOVY:
                 switch (variant) {
@@ -267,7 +262,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
                         setupPluginGroovy(false)
                         break
                     case Variant.IMPLICIT_WITH_TEST_SUITES:
-                        setupPluginGroovy(true)
+                        setupPluginGroovy()
                         break
                     case Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG:
                         setupPluginGroovy(true) {
@@ -278,7 +273,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
                         }
                         break
                     case Variant.EXPLICIT:
-                        setupPluginExplicitGroovy(false)
+                        setupPluginExplicitGroovy()
                         break
                     case Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG:
                         setupPluginExplicitGroovy(false) {
@@ -302,7 +297,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
                         setupPluginKotlin(false)
                         break
                     case Variant.IMPLICIT_WITH_TEST_SUITES:
-                        setupPluginKotlin(true)
+                        setupPluginKotlin()
                         break
                     case Variant.IMPLICIT_WITH_ADDITIONAL_CONFIG:
                         setupPluginKotlin(true) {
@@ -313,7 +308,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
                         }
                         break
                     case Variant.EXPLICIT:
-                        setupPluginExplicitKotlin(false)
+                        setupPluginExplicitKotlin()
                         break
                     case Variant.EXPLICIT_WITH_ADDITIONAL_CONFIG:
                         setupPluginExplicitKotlin(false) {
@@ -354,7 +349,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         }
     }
 
-    private void setupPluginGroovy(boolean withJvmTestSuite = true, Closure<String> additionalConfig = { "" }) {
+    private def setupPluginGroovy(boolean withJvmTestSuite = true, Closure<String> additionalConfig = { "" }) {
         buildFile = workspace.file("build.gradle")
         settingsFile = workspace.file("settings.gradle")
         settingsFile.text = ""
@@ -380,7 +375,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
             """.stripIndent(true)
     }
 
-    private void setupPluginKotlin(boolean withJvmTestSuite = true, Closure<String> additionalConfig = { "" }) {
+    private def setupPluginKotlin(boolean withJvmTestSuite = true, Closure<String> additionalConfig = { "" }) {
         buildFile = workspace.file("build.gradle.kts")
         settingsFile = workspace.file("settings.gradle.kts")
         settingsFile.text = ""
@@ -406,7 +401,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
             """.stripIndent(true)
     }
 
-    private void setupPluginExplicitGroovy(boolean applyConfigToPlugin, Closure<String> additionalTaskConfig = { "" }) {
+    private def setupPluginExplicitGroovy(boolean applyConfigToPlugin = false, Closure<String> additionalTaskConfig = { "" }) {
         buildFile = workspace.file("build.gradle")
         settingsFile = workspace.file("settings.gradle")
         settingsFile.text = ""
@@ -422,7 +417,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
 
             cucumberCompanion {
                 enableForStandardTestTask = false
-                ${applyConfigToPlugin ? invert(additionalTaskConfig.call()) : ""}
+                ${applyConfigToPlugin ? invertBooleans(additionalTaskConfig.call()) : ""}
             }
             dependencies {
             ${dependenciesRequiredForExecution()}
@@ -447,7 +442,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
             """.stripIndent(true)
     }
 
-    private void setupPluginExplicitKotlin(boolean applyConfigToPlugin, Closure<String> additionalTaskConfig = { "" }) {
+    private def setupPluginExplicitKotlin(boolean applyConfigToPlugin = false, Closure<String> additionalTaskConfig = { "" }) {
         buildFile = workspace.file("build.gradle.kts")
         settingsFile = workspace.file("settings.gradle.kts")
         settingsFile.text = ""
@@ -464,7 +459,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
 
             cucumberCompanion {
                 enableForStandardTestTask.set(false)
-                ${applyConfigToPlugin ? invert(additionalTaskConfig.call()) : ""}
+                ${applyConfigToPlugin ? invertBooleans(additionalTaskConfig.call()) : ""}
             }
             dependencies {
             ${dependenciesRequiredForExecution()}
@@ -489,7 +484,7 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
             """.stripIndent(true)
     }
 
-    def dependenciesRequiredForExecution() {
+    private def dependenciesRequiredForExecution() {
         return """\
         testImplementation(platform("org.junit:junit-bom:$JUNIT_VERSION"))
         testImplementation("io.cucumber:cucumber-java:$CUCUMBER_VERSION")
@@ -500,11 +495,11 @@ class CucumberCompanionPluginFunctionalTest extends Specification {
         """.stripIndent(true)
     }
 
-    def block(String block) {
+    private def block(String block) {
         return block?.trim() ? "{\n${block}\n}" : ""
     }
 
-    def invert(String s) {
+    private def invertBooleans(String s) {
         return s?.trim() ? s
             .replace("true", "eurt")
             .replace("false", "true")

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
@@ -44,7 +44,7 @@ abstract class CucumberCompanionExtension @Inject constructor(
     /**
      * Configuration falls back to values, configured at the extension level.
      */
-    private val defaultConfigireTask = Action<GenerateCucumberSuiteCompanionTask> {
+    private val defaultConfigureTask = Action<GenerateCucumberSuiteCompanionTask> {
         allowEmptySuites.set(this@CucumberCompanionExtension.allowEmptySuites.get())
     }
 
@@ -59,10 +59,10 @@ abstract class CucumberCompanionExtension @Inject constructor(
      */
     fun generateCucumberSuiteCompanion(
         suite: JvmTestSuite,
-    ) = generateCucumberSuiteCompanion(suite, defaultConfigireTask)
+    ) = generateCucumberSuiteCompanion(suite, defaultConfigureTask)
 
     fun generateCucumberSuiteCompanion(
         suite: JvmTestSuite,
-        configureTask: Action<GenerateCucumberSuiteCompanionTask> = defaultConfigireTask
+        configureTask: Action<GenerateCucumberSuiteCompanionTask> = defaultConfigureTask
     ) = generateCucumberSuiteCompanion(suite, taskContainer, projectLayout.buildDirectory, configureTask)
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
@@ -15,6 +15,7 @@
  */
 package com.gradle.cucumber.companion
 
+import org.gradle.api.Action
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.provider.Property
@@ -31,7 +32,7 @@ abstract class CucumberCompanionExtension @Inject constructor(
     private val projectLayout: ProjectLayout
 ) {
     companion object {
-        val NAME = "cucumberCompanion"
+        const val NAME = "cucumberCompanion"
     }
 
     @get:Input
@@ -40,12 +41,28 @@ abstract class CucumberCompanionExtension @Inject constructor(
     @get:Input
     abstract val allowEmptySuites: Property<Boolean>
 
+    /**
+     * Configuration falls back to values, configured at the extension level.
+     */
+    private val defaultConfigireTask = Action<GenerateCucumberSuiteCompanionTask> {
+        allowEmptySuites.set(this@CucumberCompanionExtension.allowEmptySuites.get())
+    }
+
     init {
         enableForStandardTestTask.convention(true)
         allowEmptySuites.convention(false)
     }
 
-    fun generateCucumberSuiteCompanion(suite: JvmTestSuite) {
-        generateCucumberSuiteCompanion(suite, taskContainer, projectLayout.buildDirectory, allowEmptySuites.get())
-    }
+    /**
+     * Keep the function w/o additional task configuration action since groovy doesn't play nice
+     * with default parameter values and is unable to find the method.
+     */
+    fun generateCucumberSuiteCompanion(
+        suite: JvmTestSuite,
+    ) = generateCucumberSuiteCompanion(suite, defaultConfigireTask)
+
+    fun generateCucumberSuiteCompanion(
+        suite: JvmTestSuite,
+        configureTask: Action<GenerateCucumberSuiteCompanionTask> = defaultConfigireTask
+    ) = generateCucumberSuiteCompanion(suite, taskContainer, projectLayout.buildDirectory, configureTask)
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
@@ -37,11 +37,15 @@ abstract class CucumberCompanionExtension @Inject constructor(
     @get:Input
     abstract val enableForStandardTestTask: Property<Boolean>
 
+    @get:Input
+    abstract val allowEmptySuites: Property<Boolean>
+
     init {
         enableForStandardTestTask.convention(true)
+        allowEmptySuites.convention(false)
     }
 
     fun generateCucumberSuiteCompanion(suite: JvmTestSuite) {
-        generateCucumberSuiteCompanion(suite, taskContainer, projectLayout.buildDirectory)
+        generateCucumberSuiteCompanion(suite, taskContainer, projectLayout.buildDirectory, allowEmptySuites.get())
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
@@ -21,26 +21,32 @@ import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskContainer
 
-fun generateCucumberSuiteCompanion(suite: JvmTestSuite, project: Project) {
+fun generateCucumberSuiteCompanion(
+    suite: JvmTestSuite,
+    project: Project,
+    allowEmptySuites: Boolean = false
+) {
     val taskContainer = project.tasks
     val buildDirectory = project.layout.buildDirectory
-    generateCucumberSuiteCompanion(suite, taskContainer, buildDirectory)
+    generateCucumberSuiteCompanion(suite, taskContainer, buildDirectory, allowEmptySuites)
 }
 
 fun generateCucumberSuiteCompanion(
     suite: JvmTestSuite,
     taskContainer: TaskContainer,
-    buildDirectory: DirectoryProperty
+    buildDirectory: DirectoryProperty,
+    allowEmptySuites: Boolean = false
 ) {
     val sourceSet = suite.sources
-    generateCucumberSuiteCompanion(taskContainer, buildDirectory, sourceSet, suite.name)
+    generateCucumberSuiteCompanion(taskContainer, buildDirectory, sourceSet, suite.name, allowEmptySuites)
 }
 
 fun generateCucumberSuiteCompanion(
     taskContainer: TaskContainer,
     buildDirectory: DirectoryProperty,
     sourceSet: SourceSet,
-    name: String
+    name: String,
+    allowEmptySuites: Boolean = false
 ) {
     val companionTask = taskContainer.register(
         "${name}GenerateCucumberSuiteCompanion",
@@ -52,6 +58,7 @@ fun generateCucumberSuiteCompanion(
         // this is a bit icky, ideally we'd use a SourceDirectorySet ourselves, but I'm not sure that is proper
         this.cucumberFeatureSources.set(sourceSet.resources.srcDirs.first())
         this.outputDirectory.set(outputDir)
+        this.allowEmptySuites.set(allowEmptySuites)
     }
     sourceSet.java.srcDir(companionTask)
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
@@ -15,30 +15,37 @@
  */
 package com.gradle.cucumber.companion
 
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskContainer
+import java.io.Serializable
+
+internal object NoOpAction : Action<GenerateCucumberSuiteCompanionTask>, Serializable {
+    override fun execute(task: GenerateCucumberSuiteCompanionTask) {
+    }
+}
 
 fun generateCucumberSuiteCompanion(
     suite: JvmTestSuite,
     project: Project,
-    allowEmptySuites: Boolean = false
+    configureTask: Action<GenerateCucumberSuiteCompanionTask> = NoOpAction
 ) {
     val taskContainer = project.tasks
     val buildDirectory = project.layout.buildDirectory
-    generateCucumberSuiteCompanion(suite, taskContainer, buildDirectory, allowEmptySuites)
+    generateCucumberSuiteCompanion(suite, taskContainer, buildDirectory, configureTask)
 }
 
 fun generateCucumberSuiteCompanion(
     suite: JvmTestSuite,
     taskContainer: TaskContainer,
     buildDirectory: DirectoryProperty,
-    allowEmptySuites: Boolean = false
+    configureTask: Action<GenerateCucumberSuiteCompanionTask> = NoOpAction
 ) {
     val sourceSet = suite.sources
-    generateCucumberSuiteCompanion(taskContainer, buildDirectory, sourceSet, suite.name, allowEmptySuites)
+    generateCucumberSuiteCompanion(taskContainer, buildDirectory, sourceSet, suite.name, configureTask)
 }
 
 fun generateCucumberSuiteCompanion(
@@ -46,7 +53,7 @@ fun generateCucumberSuiteCompanion(
     buildDirectory: DirectoryProperty,
     sourceSet: SourceSet,
     name: String,
-    allowEmptySuites: Boolean = false
+    configureTask: Action<GenerateCucumberSuiteCompanionTask> = NoOpAction
 ) {
     val companionTask = taskContainer.register(
         "${name}GenerateCucumberSuiteCompanion",
@@ -58,7 +65,7 @@ fun generateCucumberSuiteCompanion(
         // this is a bit icky, ideally we'd use a SourceDirectorySet ourselves, but I'm not sure that is proper
         this.cucumberFeatureSources.set(sourceSet.resources.srcDirs.first())
         this.outputDirectory.set(outputDir)
-        this.allowEmptySuites.set(allowEmptySuites)
+        configureTask.execute(this)
     }
     sourceSet.java.srcDir(companionTask)
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
@@ -36,13 +36,14 @@ class CucumberCompanionPlugin : Plugin<Project> {
                     project.extensions.findByType(TestingExtension::class.java)?.suites?.withType(JvmTestSuite::class.java)
                         ?.findByName(name)
                 if (testSuite != null) {
-                    generateCucumberSuiteCompanion(testSuite, project)
+                    generateCucumberSuiteCompanion(testSuite, project, extension.allowEmptySuites.get())
                 } else {
                     generateCucumberSuiteCompanion(
                         project.tasks,
                         project.layout.buildDirectory,
                         project.extensions.getByType(JavaPluginExtension::class.java).sourceSets.named(name).get(),
-                        name
+                        name,
+                        extension.allowEmptySuites.get()
                     )
                 }
             }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
@@ -36,15 +36,18 @@ class CucumberCompanionPlugin : Plugin<Project> {
                     project.extensions.findByType(TestingExtension::class.java)?.suites?.withType(JvmTestSuite::class.java)
                         ?.findByName(name)
                 if (testSuite != null) {
-                    generateCucumberSuiteCompanion(testSuite, project, extension.allowEmptySuites.get())
+                    generateCucumberSuiteCompanion(testSuite, project) {
+                        allowEmptySuites.set(extension.allowEmptySuites.get())
+                    }
                 } else {
                     generateCucumberSuiteCompanion(
                         project.tasks,
                         project.layout.buildDirectory,
                         project.extensions.getByType(JavaPluginExtension::class.java).sourceSets.named(name).get(),
-                        name,
-                        extension.allowEmptySuites.get()
-                    )
+                        name
+                    ) {
+                        allowEmptySuites.set(extension.allowEmptySuites.get())
+                    }
                 }
             }
         }

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.*
 import com.gradle.cucumber.companion.generator.CompanionGenerator
+import org.gradle.api.provider.Property
 import org.gradle.work.ChangeType
 import org.gradle.work.InputChanges
 import java.nio.file.Files
@@ -32,6 +33,9 @@ abstract class GenerateCucumberSuiteCompanionTask : DefaultTask() {
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
 
+    @get:Internal
+    abstract val allowEmptySuites: Property<Boolean>
+
     @TaskAction
     fun generateSuiteCompanionClasses(inputChanges: InputChanges) {
         val outputDir = outputDirectory.get().asFile.toPath()
@@ -40,10 +44,10 @@ abstract class GenerateCucumberSuiteCompanionTask : DefaultTask() {
             .forEach { change ->
                 val companionFile = CompanionGenerator.resolve(inputDir, outputDir, change.file.toPath())
                 when (change.changeType) {
-                    ChangeType.ADDED -> CompanionGenerator.create(companionFile)
+                    ChangeType.ADDED -> CompanionGenerator.create(companionFile, allowEmptySuites.get())
                     ChangeType.MODIFIED -> {
                         Files.deleteIfExists(companionFile.destination)
-                        CompanionGenerator.create(companionFile)
+                        CompanionGenerator.create(companionFile, allowEmptySuites.get())
                     }
                     ChangeType.REMOVED -> Files.deleteIfExists(companionFile.destination)
                     else -> {}

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
@@ -33,8 +33,12 @@ abstract class GenerateCucumberSuiteCompanionTask : DefaultTask() {
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
 
-    @get:Internal
+    @get:Input
     abstract val allowEmptySuites: Property<Boolean>
+
+    init {
+        allowEmptySuites.convention(false)
+    }
 
     @TaskAction
     fun generateSuiteCompanionClasses(inputChanges: InputChanges) {

--- a/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
@@ -21,6 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.jvm.JvmTestSuite
 import com.gradle.cucumber.companion.generateCucumberSuiteCompanion
 
-fun JvmTestSuite.generateCucumberSuiteCompanion(project: Project) {
-    generateCucumberSuiteCompanion(this, project)
+fun JvmTestSuite.generateCucumberSuiteCompanion(project: Project, allowEmptySuites: Boolean = false) {
+    generateCucumberSuiteCompanion(this, project, allowEmptySuites)
 }

--- a/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
@@ -17,10 +17,13 @@
 
 package org.gradle.kotlin.dsl
 
+import com.gradle.cucumber.companion.GenerateCucumberSuiteCompanionTask
+import com.gradle.cucumber.companion.NoOpAction
+import com.gradle.cucumber.companion.generateCucumberSuiteCompanion
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.jvm.JvmTestSuite
-import com.gradle.cucumber.companion.generateCucumberSuiteCompanion
 
-fun JvmTestSuite.generateCucumberSuiteCompanion(project: Project, allowEmptySuites: Boolean = false) {
-    generateCucumberSuiteCompanion(this, project, allowEmptySuites)
-}
+fun JvmTestSuite.generateCucumberSuiteCompanion(
+    project: Project, configureTask: Action<GenerateCucumberSuiteCompanionTask> = NoOpAction
+) = generateCucumberSuiteCompanion(this, project, configureTask)

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
@@ -80,6 +80,7 @@ abstract class BaseCucumberCompanionMavenFuncTest extends BaseMavenFuncTest {
             addManagedDependency("org.junit", "junit-bom", JUNIT_VERSION)
             addDependency("org.junit.jupiter", "junit-jupiter", null, "test")
             addDependency("org.junit.platform", "junit-platform-suite", null, "test")
+            addDependency("org.junit.platform", "junit-platform-launcher", null, "test")
             addDependency("io.cucumber", "cucumber-java", CUCUMBER_VERSION, "test")
             addDependency("io.cucumber", "cucumber-junit-platform-engine", CUCUMBER_VERSION, "test")
             it.with(pom)

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoForFailsafeIntegrationTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoForFailsafeIntegrationTest.groovy
@@ -48,7 +48,7 @@ class GenerateCucumberCompanionMojoForFailsafeIntegrationTest extends BaseCucumb
         result.log.each { println(it) }
 
         and:
-        def expectedCompanions = expectedCompanionFiles("IT")
+        def expectedCompanions = expectedCompanionFiles(suffix: "IT")
 
         expectedCompanions.forEach {
             companionAssertions.assertCompanionFile(it)
@@ -71,7 +71,7 @@ class GenerateCucumberCompanionMojoForFailsafeIntegrationTest extends BaseCucumb
         result.log.each { println(it) }
 
         and:
-        def expectedCompanions = expectedCompanionFiles("IT")
+        def expectedCompanions = expectedCompanionFiles(suffix: "IT")
         expectedCompanions.forEach {
             verifyAll(failsafeFireTestReport(it)) {
                 Files.exists(it)

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoIntegrationTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoIntegrationTest.groovy
@@ -48,7 +48,7 @@ class GenerateCucumberCompanionMojoIntegrationTest extends BaseCucumberCompanion
         result.log.each { println(it) }
 
         and:
-        def expectedCompanions = expectedCompanionFiles("Test")
+        def expectedCompanions = expectedCompanionFiles(suffix: "Test")
 
         expectedCompanions.forEach {
             companionAssertions.assertCompanionFile(it)
@@ -71,7 +71,7 @@ class GenerateCucumberCompanionMojoIntegrationTest extends BaseCucumberCompanion
         result.log.each { println(it) }
 
         and:
-        def expectedCompanions = expectedCompanionFiles("Test", false, succeedingFeatures)
+        def expectedCompanions = expectedCompanionFiles(suffix: "Test", succeedingFeatures)
         expectedCompanions.forEach {
             verifyAll(sureFireTestReport(it)) {
                 Files.exists(it)
@@ -89,7 +89,7 @@ class GenerateCucumberCompanionMojoIntegrationTest extends BaseCucumberCompanion
         configureCompanionPluginToAllowEmptySuites()
         createFeatureFiles(workspace.fileSystem)
         createStepFiles(workspace.fileSystem)
-        createPostDiscoveryFilter(workspace.fileSystem)
+        createPostDiscoveryFilter(workspace.fileSystem, "$CucumberFeature.USER_PROFILE.packageName.$CucumberFeature.USER_PROFILE.className")
         registerPostDiscoveryFilter(workspace.fileSystem)
 
         when:
@@ -101,7 +101,7 @@ class GenerateCucumberCompanionMojoIntegrationTest extends BaseCucumberCompanion
         result.log.each { println(it) }
 
         and:
-        def expectedCompanions = expectedCompanionFiles("Test", true, allSucceedingFeatures)
+        def expectedCompanions = expectedCompanionFiles(suffix: "Test", allowEmptySuites: true, allSucceedingFeatures)
 
         expectedCompanions.forEach {
             companionAssertions.assertCompanionFile(it)

--- a/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojo.java
+++ b/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojo.java
@@ -51,6 +51,9 @@ public class GenerateCucumberCompanionMojo extends AbstractMojo {
     @Parameter(defaultValue = "Test", required = true)
     private String generatedFileNameSuffix;
 
+    @Parameter(defaultValue = "false")
+    private boolean allowEmptySuites;
+
     @Parameter(readonly = true, defaultValue = "${project}")
     private MavenProject project;
 
@@ -108,7 +111,7 @@ public class GenerateCucumberCompanionMojo extends AbstractMojo {
                 .mapToInt(companionFile -> {
                     try {
                         logDebug(() -> "Creating " + companionFile);
-                        CompanionGenerator.create(companionFile);
+                        CompanionGenerator.create(companionFile, allowEmptySuites);
                         return 1;
                     } catch (IOException e) {
                         throw new RuntimeException("Could not create companion files.", e);


### PR DESCRIPTION
This PR adds optional boolean flag to the generated `@Suite` annotation in companions.
It will improve dev experience while integrating with [Test Retry Gradle Plugin](https://github.com/gradle/test-retry-gradle-plugin), as mentioned [here](https://github.com/cucumber/cucumber-jvm/tree/main/cucumber-junit-platform-engine#using-gradle).

@skuzzle , @leonard84 , @marcphilipp : would you be so kind and have a look please?
