### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ group=com.gradle.cucumber.companion
 # NOTE: Keep version in sync with Readme.adoc
 version=1.0.1
 org.gradle.java.installations.fromEnv=JDK_1_8,JDK8,JDK9,JDK17
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
This system property will disable sending `maven-metadata.xml.sha512` files to our repository. The files are not correctly handled by the repository.