### PR TITLE
Use liberica because temurin JDK8 is no longer available?

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -7,7 +7,7 @@ runs:
   - name: 'Set up JDK 8'
     uses: actions/setup-java@v3
     with:
-      distribution: 'temurin'
+      distribution: 'liberica'
       java-version: 8
   - name: Prepare JDK8 env var
     shell: bash


### PR DESCRIPTION
Checks on PR #84 failed, because the workflow could not install JDK8 on macOS:

> Installed distributions
  Trying to resolve the latest version from remote
  Error: Could not find satisfied version for SemVer '8'. 
  Available versions: 22.0.1+8, 22.0.0+36, 21.0.3+9.0.LTS, 21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9, 20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9, 18.0.1+10, 18.0.0+36, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101, 17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7, 17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.23+9, 11.0.22+7.1, 11.0.22+7, 11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8, 11.0.16+101, 11.0.16+8, 11.0.15+10

This is kind of odd, because at least on the temurin site, macOS+JDK8 is listed as supported.
Anyway, this PR switches to liberica as vendor for JDK8 and it seems to work.