### PR TITLE
Update license headers

### DIFF
--- a/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionFile.java
+++ b/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionGenerator.java
+++ b/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/CompanionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/GeneratedClassOptions.java
+++ b/companion-generator/src/main/java/com/gradle/cucumber/companion/generator/GeneratedClassOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CompanionAssertions.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CompanionAssertions.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFeature.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFeature.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFixture.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/CucumberFixture.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedCompanionFile.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedCompanionFile.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedOutcome.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/fixtures/ExpectedOutcome.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/testcontext/TestContext.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/testcontext/TestContext.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/testcontext/TestContextExtension.groovy
+++ b/companion-generator/src/testFixtures/groovy/com/gradle/cucumber/companion/testcontext/TestContextExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/CucumberCompanionPluginFunctionalTest.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/CucumberCompanionPluginFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/TestContextRunner.groovy
+++ b/gradle-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/TestContextRunner.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/CucumberCompanionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GenerateCucumberSuiteCompanionTask.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GeneratedClassCustomization.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/cucumber/companion/GeneratedClassCustomization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
+++ b/gradle-plugin/src/main/kotlin/com/gradle/kotlin/dsl/CucumberCompanion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/BaseCucumberCompanionMavenFuncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoForFailsafeIntegrationTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoForFailsafeIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoIntegrationTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojoIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/BaseMavenFuncTest.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/BaseMavenFuncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/MavenDistribution.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/MavenDistribution.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/MavenWorkspace.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/MavenWorkspace.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/Pom.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/Pom.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/XmlTree.groovy
+++ b/maven-plugin/src/functionalTest/groovy/com/gradle/maven/functest/XmlTree.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojo.java
+++ b/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GenerateCucumberCompanionMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GeneratedClassCustomization.java
+++ b/maven-plugin/src/main/java/com/gradle/cucumber/companion/maven/GeneratedClassCustomization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The style check fails because license headers got out of date. This prevents renovate PRs from being merged: https://github.com/gradle/cucumber-companion/pull/150. I updated all headers at once with `licenseFormat` task.