### PR TITLE
Add coverage for Gradle 9 and update misc dependencies

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -6,7 +6,7 @@ runs:
   - uses: actions/checkout@v5
 
   - name: 'Set up JDK 8'
-    uses: actions/setup-java@v4
+    uses: actions/setup-java@v5
     with:
       distribution: 'liberica'
       java-version: 8
@@ -16,7 +16,7 @@ runs:
     run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
 
   - name: 'Set up JDK 17'
-    uses: actions/setup-java@v4
+    uses: actions/setup-java@v5
     with:
       distribution: 'temurin'
       java-version: 17

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -3,7 +3,7 @@ description: Installs required JDKs for building and testing
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v5
 
   - name: 'Set up JDK 8'
     uses: actions/setup-java@v4

--- a/.github/workflows/check-teamcity.yml
+++ b/.github/workflows/check-teamcity.yml
@@ -12,7 +12,7 @@ jobs:
   verfy-team-city-configs:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/check-teamcity.yml
+++ b/.github/workflows/check-teamcity.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: "Setup Build Environment"
       uses: ./.github/actions/setup-environment

--- a/.github/workflows/verify-publications.yml
+++ b/.github/workflows/verify-publications.yml
@@ -16,7 +16,7 @@ jobs:
   build-and-verify:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: "Setup Build Environment"
       uses: ./.github/actions/setup-environment

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: "Setup Build Environment"
       uses: ./.github/actions/setup-environment

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -25,6 +25,7 @@ afterEvaluate {
 
 val crossVersions = listOf(
     CrossVersionTest(libs.versions.gradleMinSupported.get(), false), // lowest supported versions as jvm-test-suites was added here
+    CrossVersionTest(libs.versions.gradleMaxSupported.get(), true), // max supported version as we compile against a fixed 8.x version of the Gradle API
     CrossVersionTest(GradleVersion.current().version, true),
 )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ spock = "2.3-groovy-3.0"
 mavenMinCompatible = "3.8.6"
 mavenMaxCompatible = "3.9.11"
 gradleMinSupported = "7.3"
+gradleMaxSupported = "9.0.0"
 
 junit = "5.13.4"
 cucumber = "7.27.2"

--- a/gradle/plugins/settings.gradle.kts
+++ b/gradle/plugins/settings.gradle.kts
@@ -9,4 +9,3 @@ dependencyResolutionManagement {
 rootProject.name = "plugins"
 
 include("build-logic")
-include("maven-plugin-testing")


### PR DESCRIPTION
The Kotlin version bundled with Gradle 9.x is incompatible with the Kotlin version bundled with Gradle 7.3 (i.e., the min Gradle version the plugin supports). Therefore, we can't compile the plugin against Gradle 9.x API. We have decided to stay on the latest 8.x Gradle API and just add coverage for newer Gradle versions.